### PR TITLE
Add Semgrep CI workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,19 @@
+name: Semgrep CI
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/semgrep.yml
+  schedule:
+    - cron: 0 1 * * *
+
+jobs:
+  semgrep:
+    uses: p0-security/workflows-public/.github/workflows/semgrep-reusable.yml@main
+    secrets:
+      SEMGREP_RULES_APP_ID: ${{ secrets.SEMGREP_RULES_APP_ID }}
+      SEMGREP_RULES_APP_PRIVATE_KEY: ${{ secrets.SEMGREP_RULES_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Adds Semgrep scanning via the centralized `p0-security/workflows-public` reusable workflow
- Runs on PRs (diff-aware), pushes to main, daily schedule, and manual trigger

## Test plan
- [x] Confirm `SEMGREP_RULES_APP_ID` and `SEMGREP_RULES_APP_PRIVATE_KEY` org secrets are accessible to this repo
- [x] Verify Semgrep CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)